### PR TITLE
Fix 首次进入时页面列表会向上偏移

### DIFF
--- a/SuperSwipeRefreshLayout-Demo-AS/app/src/main/java/net/mobctrl/views/SuperSwipeRefreshLayout.java
+++ b/SuperSwipeRefreshLayout-Demo-AS/app/src/main/java/net/mobctrl/views/SuperSwipeRefreshLayout.java
@@ -469,7 +469,7 @@ public class SuperSwipeRefreshLayout extends ViewGroup {
         if (mTarget == null) {
             return;
         }
-        int distance = mCurrentTargetOffsetTop + mHeadViewContainer.getHeight();
+        int distance = mCurrentTargetOffsetTop + mHeadViewContainer.getMeasuredHeight();
         if (!targetScrollWithLayout) {
             // 判断标志位，如果目标View不跟随手指的滑动而滑动，将下拉偏移量设置为0
             distance = 0;

--- a/SuperSwipeRefreshLayout-Demo/src/net/mobctrl/views/SuperSwipeRefreshLayout.java
+++ b/SuperSwipeRefreshLayout-Demo/src/net/mobctrl/views/SuperSwipeRefreshLayout.java
@@ -469,7 +469,7 @@ public class SuperSwipeRefreshLayout extends ViewGroup {
         if (mTarget == null) {
             return;
         }
-        int distance = mCurrentTargetOffsetTop + mHeadViewContainer.getHeight();
+        int distance = mCurrentTargetOffsetTop + mHeadViewContainer.getMeasuredHeight();
         if (!targetScrollWithLayout) {
             // 判断标志位，如果目标View不跟随手指的滑动而滑动，将下拉偏移量设置为0
             distance = 0;


### PR DESCRIPTION
在 onLayout 里面应该用 getMeasuredHeight() 获取子 View 的高度，否则如果 View 没有显示过的话拿到的会是 0