### PR TITLE
[modify]修复mHeadViewContainer及mFooterViewContainer宽度没有正确计算的问题

### DIFF
--- a/SuperSwipeRefreshLayout.java
+++ b/SuperSwipeRefreshLayout.java
@@ -510,10 +510,10 @@ public class SuperSwipeRefreshLayout extends ViewGroup {
                                 - getPaddingTop() - getPaddingBottom(),
                         MeasureSpec.EXACTLY));
         mHeadViewContainer.measure(MeasureSpec.makeMeasureSpec(
-                mHeaderViewWidth, MeasureSpec.EXACTLY), MeasureSpec
+                MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.EXACTLY), MeasureSpec
                 .makeMeasureSpec(3 * mHeaderViewHeight, MeasureSpec.EXACTLY));
         mFooterViewContainer.measure(MeasureSpec.makeMeasureSpec(
-                mFooterViewWidth, MeasureSpec.EXACTLY), MeasureSpec
+                MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.EXACTLY), MeasureSpec
                 .makeMeasureSpec(mFooterViewHeight, MeasureSpec.EXACTLY));
         if (!mUsingCustomStart && !mOriginalOffsetCalculated) {
             mOriginalOffsetCalculated = true;


### PR DESCRIPTION
使用中发现在父布局中margin或者padding的情况下，底部（可能头部也是这样的）view会被挡住部分，查看里面实现发现是将mFooterViewContainer和mHeaderViewContainer的宽度都是以屏幕宽度作为自己的宽度的，这里稍微可以改进一下，在onMeasure方法中进行了部分修改